### PR TITLE
Add warning message to solve_emr.R

### DIFF
--- a/R/solve_emr.R
+++ b/R/solve_emr.R
@@ -126,6 +126,8 @@ solve_emr <- function(model, maxit = 1000, start = NULL, ...){
                            quiet = TRUE
         )
       }
+      
+      if(sol$message != "Successful convergence") warning(sol$message)
 
       #if(sol$convergence != 0) break
       #cat(name, sol$iter, "\n")


### PR DESCRIPTION
Adds a warning message to the output of the function whenever convergence is not achieved or error happens.